### PR TITLE
Local Development Proxy Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v4.2.0
+
+### Added 
+
+- Local Development Proxy Server. See #164
+
 ## v4.1.1
 
 ### Changed 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (4.1.1)
+    lamby (4.2.0)
       rack
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    webrick (1.8.1)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -189,6 +190,7 @@ DEPENDENCIES
   pry
   rails
   rake
+  webrick
 
 BUNDLED WITH
    2.3.26

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,13 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = begin
+    if ENV['TEST_FILE']
+      [ENV['TEST_FILE']]
+    else
+      FileList["test/**/*_test.rb"]
+    end
+  end
   t.verbose = false
   t.warning = false
 end

--- a/lamby.gemspec
+++ b/lamby.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-focus'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'webrick'
 end

--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -35,5 +35,7 @@ module Lamby
   end
 
   autoload :SsmParameterStore, 'lamby/ssm_parameter_store'
+  autoload :ProxyContext, 'lamby/proxy_context'
+  autoload :ProxyServer, 'lamby/proxy_server'
 
 end

--- a/lib/lamby/proxy_context.rb
+++ b/lib/lamby/proxy_context.rb
@@ -1,0 +1,25 @@
+module Lamby
+  # This class is used by the `lamby:proxy_server` Rake task to run a
+  # Rack server for local development proxy. Specifically, this class 
+  # accepts a JSON respresentation of a Lambda context object converted 
+  # to a Hash as the single arugment.
+  # 
+  class ProxyContext
+    def initialize(data)
+      @data = data
+    end
+
+    def method_missing(method_name, *args, &block)
+      key = method_name.to_s
+      if @data.key?(key)
+        @data[key]
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @data.key?(method_name.to_s) || super
+    end
+  end
+end

--- a/lib/lamby/proxy_server.rb
+++ b/lib/lamby/proxy_server.rb
@@ -1,0 +1,34 @@
+module Lamby
+  class ProxyServer
+    
+    METHOD_NOT_ALLOWED = <<-HEREDOC.strip
+      <h1>Method Not Allowed</h1>
+      <p>Please POST to this endpoint with an application/json content type and JSON payload of your Lambda's event and context.<p>
+      <p>Example: <code>{ "event": event, "context": context }</code></p>
+    HEREDOC
+    
+    def call(env)
+      return method_not_allowed unless method_allowed?(env)
+      event, context = event_and_context(env)
+      Lamby.cmd event: event, context: context
+    end
+
+    private
+
+    def event_and_context(env)
+      data = env['rack.input'].dup.read
+      json = JSON.parse(data)
+      [ json['event'], Lamby::ProxyContext.new(json['context']) ]
+    end
+
+    def method_allowed?(env)
+      env['REQUEST_METHOD'] == 'POST' && env['CONTENT_TYPE'] == 'application/json'
+    end
+
+    def method_not_allowed
+      { statusCode: 405,
+        headers: {"Content-Type" => "text/html"},
+        body: METHOD_NOT_ALLOWED.dup }
+    end
+  end
+end

--- a/lib/lamby/proxy_server.rb
+++ b/lib/lamby/proxy_server.rb
@@ -10,7 +10,7 @@ module Lamby
     def call(env)
       return method_not_allowed unless method_allowed?(env)
       event, context = event_and_context(env)
-      Lamby.cmd event: event, context: context
+      lambda_to_rack Lamby.cmd(event: event, context: context)
     end
 
     private
@@ -26,9 +26,11 @@ module Lamby
     end
 
     def method_not_allowed
-      { statusCode: 405,
-        headers: {"Content-Type" => "text/html"},
-        body: METHOD_NOT_ALLOWED.dup }
+      [405, {"Content-Type" => "text/html"}, [ METHOD_NOT_ALLOWED.dup ]]
+    end
+
+    def lambda_to_rack(response)
+      [ 200, {"Content-Type" => "application/json"}, response.to_json ]
     end
   end
 end

--- a/lib/lamby/proxy_server.rb
+++ b/lib/lamby/proxy_server.rb
@@ -30,7 +30,7 @@ module Lamby
     end
 
     def lambda_to_rack(response)
-      [ 200, {"Content-Type" => "application/json"}, response.to_json ]
+      [ 200, {"Content-Type" => "application/json"}, [ response.to_json ] ]
     end
   end
 end

--- a/lib/lamby/railtie.rb
+++ b/lib/lamby/railtie.rb
@@ -1,5 +1,9 @@
 module Lamby
   class Railtie < ::Rails::Railtie
     config.lamby = Lamby::Config.config
+
+    rake_tasks do
+      load 'lamby/tasks.rake'
+    end
   end
 end

--- a/lib/lamby/tasks.rake
+++ b/lib/lamby/tasks.rake
@@ -1,0 +1,7 @@
+namespace :lamby do
+  task :proxy_server => [:environment] do
+    require 'webrick'
+    port = ENV['LAMBY_PROXY_PORT'] || 3000
+    Rack::Handler::WEBrick.run Lamby::ProxyServer.new, Port: port
+  end
+end

--- a/lib/lamby/tasks.rake
+++ b/lib/lamby/tasks.rake
@@ -2,6 +2,7 @@ namespace :lamby do
   task :proxy_server => [:environment] do
     require 'webrick'
     port = ENV['LAMBY_PROXY_PORT'] || 3000
-    Rack::Handler::WEBrick.run Lamby::ProxyServer.new, Port: port
+    bind = ENV['LAMBY_PROXY_BIND'] || '0.0.0.0'
+    Rack::Handler::WEBrick.run Lamby::ProxyServer.new, Port: port, BindAddress: bind
   end
 end

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '4.1.1'
+  VERSION = '4.2.0'
 end

--- a/test/proxy_context_test.rb
+++ b/test/proxy_context_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class ProxyContextTest < LambySpec
+  
+  let(:context_data) { TestHelpers::LambdaContext.raw_data }
+  let(:proxy_context) { Lamby::ProxyContext.new(context_data) }
+
+  it 'should respond to all context methods' do
+    context_data.keys.each do |key|
+      response = proxy_context.respond_to?(key.to_sym)
+      expect(response).must_equal true, "Expected context to respond to #{key.inspect}"
+    end
+  end
+
+  it 'should return the correct value for each context method' do
+    expect(proxy_context.clock_diff).must_equal 1681486457423
+    expect(proxy_context.deadline_ms).must_equal 1681492072985
+    expect(proxy_context.aws_request_id).must_equal "d6f5961b-5034-4db5-b3a9-fa378133b0f0"
+  end
+
+  it 'should raise an error for unknown methods' do
+    expect { proxy_context.foo }.must_raise NoMethodError
+  end
+
+  it 'should return false for respond_to? for a unknown method' do
+    expect(proxy_context.respond_to?(:foo)).must_equal false
+  end
+
+end

--- a/test/proxy_server_test.rb
+++ b/test/proxy_server_test.rb
@@ -1,0 +1,47 @@
+require 'net/http'
+require 'test_helper'
+
+class ProxyServerTest < LambySpec
+  let(:event)    { TestHelpers::Events::HttpV2.create }
+  let(:context)  { TestHelpers::LambdaContext.raw_data }
+  let(:rack_app) { Rack::Builder.new { run lambda { |env| [200, {}, StringIO.new('{"statusCode": 200}')] } }.to_app }
+  let(:proxy)    { Lamby::ProxyServer.new }
+
+  before { Lamby.config.rack_app = rack_app }
+  
+  it 'should return a 405 helpful message on GET' do
+    response = proxy.call(env("REQUEST_METHOD" => 'GET'))
+    expect(response[:statusCode]).must_equal 405
+    expect(response[:headers]).must_equal({"Content-Type" => "text/html"})
+    expect(response[:body]).must_include 'Method Not Allowed'
+  end
+  
+  it 'should call Lamby.cmd on POST' do
+    response = proxy.call(env)
+    expect(response[:statusCode]).must_equal 200
+    expect(response[:headers]).must_equal({})
+    expect(response[:body]).must_equal '{"statusCode": 200}'
+  end
+
+  private
+
+  def env(options={})
+    json = {"event": event, "context": context}.to_json
+    { 'REQUEST_METHOD' => 'POST',
+      'PATH_INFO' => '/',
+      'QUERY_STRING' => '',
+      'SERVER_NAME' => 'localhost',
+      'SERVER_PORT' => '3000',
+      'HTTP_VERSION' => 'HTTP/1.1',
+      'rack.version' => Rack::VERSION,
+      'rack.input' => StringIO.new(json),
+      'rack.url_scheme' => 'http',
+      'rack.errors' => $stderr,
+      'rack.multithread' => true,
+      'rack.multiprocess' => false,
+      'rack.run_once' => false,
+      'CONTENT_TYPE' => 'application/json',
+      'CONTENT_LENGTH' => json.bytesize.to_s
+    }.merge(options)
+  end
+end

--- a/test/test_helper/lambda_context.rb
+++ b/test/test_helper/lambda_context.rb
@@ -1,6 +1,22 @@
 module TestHelpers
   class LambdaContext
 
+    RAW_DATA ={
+      "clock_diff" => 1681486457423,
+      "deadline_ms" => 1681492072985,
+      "aws_request_id" => "d6f5961b-5034-4db5-b3a9-fa378133b0f0",
+      "invoked_function_arn" => "arn:aws:lambda:us-east-1:576043675419:function:lamby-ws-production-WSConnectLambda-5in18cNskwz6",
+      "log_group_name" => "/aws/lambda/lamby-ws-production-WSConnectLambda-5in18cNskwz6",
+      "log_stream_name" => "2023/04/14/[$LATEST]55a1d458479a4546b64acca17af3a69f",
+      "function_name" => "lamby-ws-production-WSConnectLambda-5in18cNskwz6",
+      "memory_limit_in_mb" => "1792",
+      "function_version" => "$LATEST"
+    }.freeze 
+
+    def self.raw_data
+      RAW_DATA.dup
+    end
+
     def clock_diff
       1585237646907
     end


### PR DESCRIPTION
In support of the following work where we now need a fast feedback loop for the final WebSocket integration work.

- https://github.com/rails-lambda/lamby/issues/74
- https://github.com/rails-lambda/websocket-demo
- https://github.com/rails-lambda/live-development

The idea is pretty simple, within an app like the `websocket-demo` one, we would start a development proxy server within the context of the Rails Application using `rake labmy:proxy_server`. This will start up a WEBrick web server that accepts a simple endpoint to POST Lambda event & context objects as a single JSON structure like `{"event": {}, "context": {}}`. All the proxy server does is send this right down to `Lamby.cmd` where everything the app needs to do from web requests, jobs, websockets, etc... JUST WORKS™. The result of that call is a standard Lambda response like `{statusCode: ..., headers: ..., body: ...}` or whatever. The idea is the proxy server need not care. We simply take the Lamby.cmd response and stuff it into the JSON body of the Rack response. Tooling (not specified here) would take that HTTP response body and send it directly to the "Lambda Proxy" as if the Lambda itself did all the work. The fun looks something like this. The important part to call out is that all the pink lines are local Rails (in our case) talking to AWS Resources. So cool!

```mermaid
flowchart TB
  %% Objects
  usr[/User/]
  subgraph aws["AWS Environment"]
    fun(Function URL)
		api(API Gateway)
    lam(Lambda Proxy)
    ddb[(DynamoDB)]:::node-org
  end
  subgraph local["Local Environment"]
    subgraph app["Application"]
      proxy(Proxy Server)
    end
  end
  %% Flow
  usr <--> |/*| fun
  usr <--> |/cable| api
  fun <--> lam
  api --> lam
  lam <--> |tailscale| proxy
  app --> api
  app --> ddb
  %% Styles
  classDef node fill:#a99ff0,stroke:#fff,stroke-width:4px,color:#000;
  classDef node-wht fill:white,stroke:#ccc,stroke-width:1px,color:black;
  classDef node-org fill:#fdf3ea,stroke:#f7c296,stroke-width:2px,color:#000;
  classDef desc fill:white,stroke:#ccc,stroke-width:1px,color:black,font-size:12px;
  classDef node-sml font-size:13px,line-height:2em;
  classDef fs13 font-size:13px,line-height:1em;
	linkStyle 4 stroke:#f28add
	linkStyle 5 stroke:#f28add
	linkStyle 6 stroke:#f28add
  class aws node-wht
  class local node-wht
```