### PR TITLE
New Lamby::Command for IRB Style Eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v4.3.0
+
+### Changed
+
+- Default Lamby::Runner::PATTERNS to allow everything.
+
+### Added
+
+- New Lamby::Command for IRB style top level binding evals.
+
 ## v4.2.1
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (4.2.1)
+    lamby (4.3.0)
       rack
 
 GEM

--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -9,6 +9,7 @@ require 'lamby/rack_rest'
 require 'lamby/rack_http'
 require 'lamby/debug'
 require 'lamby/runner'
+require 'lamby/command'
 require 'lamby/handler'
 
 if defined?(Rails)

--- a/lib/lamby/command.rb
+++ b/lib/lamby/command.rb
@@ -1,0 +1,42 @@
+module Lamby
+  class Command
+
+    class << self
+
+      def handle?(event)
+        event.dig 'lamby', 'command'
+      end
+
+      def cmd(event:, context:)
+        new(event).call
+      end
+
+    end
+
+    def initialize(event)
+      @event = event
+      @body = ''
+    end
+
+    def call
+      begin
+        body = eval(command, TOPLEVEL_BINDING).to_s
+        body = body.inspect if body =~ /\A"/ && body =~ /"\z/
+        { statusCode: 200, headers: {}, body: body }
+      rescue Exception => e
+        body = "#<#{e.class}:#{e.message}>".tap do |b|
+          if e.backtrace
+            b << "\n"
+            b << e.backtrace.join("\n")
+          end
+        end
+        { statusCode: 422, headers: {}, body: body }
+      end
+    end
+
+    def command
+      @event.dig 'lamby', 'command'
+    end
+
+  end
+end

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -92,9 +92,10 @@ module Lamby
         Lambdakiq.cmd event: @event, context: @context
       elsif lambda_cable?
         LambdaCable.cmd event: @event, context: @context
+      elsif command?
+        Lamby::Command.cmd event: @event, context: @context
       elsif runner?
-        @status, @headers, @body = Runner.call(@event)
-        { statusCode: status, headers: headers, body: body }
+        Lamby::Runner.cmd event: @event, context: @context
       elsif event_bridge?
         Lamby.config.event_bridge_handler.call @event, @context
       else
@@ -121,7 +122,11 @@ module Lamby
     end
 
     def runner?
-      Runner.handle?(@event)
+      Lamby::Runner.handle?(@event)
+    end
+
+    def command?
+      Lamby::Command.handle?(@event)
     end
 
     def lambda_cable?

--- a/lib/lamby/runner.rb
+++ b/lib/lamby/runner.rb
@@ -5,9 +5,7 @@ module Lamby
     class Error < StandardError ; end
     class UnknownCommandPattern < Error ; end
 
-    PATTERNS = [
-      %r{\A\./bin/(rails|rake) db:migrate.*}
-    ]
+    PATTERNS = [%r{.*}]
 
     class << self
 
@@ -15,7 +13,7 @@ module Lamby
         event.dig 'lamby', 'runner'
       end
 
-      def call(event)
+      def cmd(event:, context:)
         new(event).call
       end
 
@@ -34,7 +32,7 @@ module Lamby
         puts @body
         thread.value.exitstatus
       end
-      [status, {}, StringIO.new(@body)]
+      { statusCode: status, headers: {}, body: @body }
     end
 
     def command

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '4.2.1'
+  VERSION = '4.3.0'
 end


### PR DESCRIPTION
To work with the new Lamby Console (https://github.com/rails-lambda/lamby_console) which will do both Runner and Command support.