### PR TITLE
Safely Pass Percent Symbols in Paths

### DIFF
--- a/lib/lamby/rack_http.rb
+++ b/lib/lamby/rack_http.rb
@@ -78,6 +78,7 @@ module Lamby
     def path_info
       stage = event.dig('requestContext', 'stage')
       spath = event.dig('requestContext', 'http', 'path') || event.dig('requestContext', 'path')
+      spath = event['rawPath'] if spath != event['rawPath'] && !payload_version_one?
       spath.sub /\A\/#{stage}/, ''
     end
 

--- a/test/dummy_app/app/controllers/application_controller.rb
+++ b/test/dummy_app/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
     raise 'hell'
   end
 
+  def percent
+    render
+  end
+
   def cooks
     cookies['1'] = '1'
     cookies['2'] = '2'

--- a/test/dummy_app/app/views/application/percent.html.erb
+++ b/test/dummy_app/app/views/application/percent.html.erb
@@ -1,0 +1,2 @@
+Params: <%= params[:path] %>
+Request Path: <%= request.path %>

--- a/test/dummy_app/config/routes.rb
+++ b/test/dummy_app/config/routes.rb
@@ -4,6 +4,7 @@ Dummy::Application.routes.draw do
   post 'login', to: 'application#login'
   delete 'logout', to: 'application#logout'
   get 'exception', to: 'application#exception'
+  get 'percent/*path', to: 'application#percent'
   get 'cooks', to: 'application#cooks'
   get 'redirect_test', to: redirect('/')
 end

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -86,6 +86,17 @@ class HandlerTest < LambySpec
       expect(result[:body]).must_match %r{We're sorry, but something went wrong.}
       expect(result[:body]).must_match %r{This file lives in public/500.html}
     end
+    
+    it 'get - percent' do
+      event = TestHelpers::Events::HttpV2.create(
+        'rawPath' => '/production/percent/dwef782jkif%3d',
+        'requestContext' => { 'http' => {'path' => '/production/percent/dwef782jkif='} }
+      )
+      result = Lamby.handler app, event, context, rack: :http
+      expect(result[:statusCode]).must_equal 200
+      expect(result[:body]).must_match %r{Params: dwef782jkif=}
+      expect(result[:body]).must_match %r{Request Path: /percent/dwef782jkif%3}
+    end
 
   end
 


### PR DESCRIPTION
Here is an example of running Rails under Puma with something like `/test/dwef782jkif%3d` in the path:

```
Started GET "/test/dwef782jkif%3d" for 172.19.0.1 at 2023-07-07 19:19:30 +0000
Processing by ApplicationController#test as HTML
  Parameters: {"path"=>"dwef782jkif="}
Completed 200 OK in 2ms (ActiveRecord: 0.0ms | Allocations: 113)
```

Prior to this change, here is what it looked like in Lamby:

```
Started GET "/test/dwef782jkif=" for 98.166.4.233 at 2023-07-07 19:11:39 +0000
Processing by ApplicationController#test as HTML
  Parameters: {"path"=>"dwef782jkif="}
Completed 200 OK in 2ms (ActiveRecord: 0.0ms | Allocations: 114)
```

We learned the same lessons with query params, always trust Raw. Thankfully, HTTP v2 allows that to happen. 

ℹ️  There are [some folks](https://www.reddit.com/r/aws/comments/ykpvsn/api_gateway_http_proxy_is_unencoding_my_url/) that use `AWS::ApiGatewayV2::Integration` with API Gateway to proxy requests to AWS Services like Lambda, but the mapping request parameter tooling (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html) does not provide a way to get to the raw value. RIP 🪦 
