### PR TITLE
Remove uninitialized constants

### DIFF
--- a/lib/lamby/rack_alb.rb
+++ b/lib/lamby/rack_alb.rb
@@ -47,9 +47,6 @@ module Lamby
         ::Rack::RACK_URL_SCHEME => headers['x-forwarded-proto'],
         ::Rack::RACK_INPUT => StringIO.new(body || ''),
         ::Rack::RACK_ERRORS => $stderr,
-        ::Rack::RACK_MULTITHREAD => false,
-        ::Rack::RACK_MULTIPROCESS => false,
-        ::Rack::RACK_RUNONCE => false,
         LAMBDA_EVENT => event,
         LAMBDA_CONTEXT => context
       }.tap do |env|

--- a/lib/lamby/rack_http.rb
+++ b/lib/lamby/rack_http.rb
@@ -42,9 +42,6 @@ module Lamby
         ::Rack::RACK_URL_SCHEME => 'https',
         ::Rack::RACK_INPUT => StringIO.new(body || ''),
         ::Rack::RACK_ERRORS => $stderr,
-        ::Rack::RACK_MULTITHREAD => false,
-        ::Rack::RACK_MULTIPROCESS => false,
-        ::Rack::RACK_RUNONCE => false,
         LAMBDA_EVENT => event,
         LAMBDA_CONTEXT => context
       }.tap do |env|

--- a/lib/lamby/rack_rest.rb
+++ b/lib/lamby/rack_rest.rb
@@ -36,9 +36,6 @@ module Lamby
         ::Rack::RACK_URL_SCHEME => 'https',
         ::Rack::RACK_INPUT => StringIO.new(body || ''),
         ::Rack::RACK_ERRORS => $stderr,
-        ::Rack::RACK_MULTITHREAD => false,
-        ::Rack::RACK_MULTIPROCESS => false,
-        ::Rack::RACK_RUNONCE => false,
         LAMBDA_EVENT => event,
         LAMBDA_CONTEXT => context
       }.tap do |env|


### PR DESCRIPTION
# Summary
Fixes #171. The constants were removed from Rack in https://github.com/rack/rack/pull/1720 so removed them here to prevent the initialized constants error.